### PR TITLE
feat: Stellar Network Status Monitoring

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAppDispatch, useAppSelector } from '@/store';
-import { getAccountStatus, getBalance, deployAccount, fundAccount } from '@/store/slices/accountSlice';
+import { getAccountStatus, getBalance, deployAccount, fundAccount, getStellarNetworkStatus } from '@/store/slices/accountSlice';
 import { loadUser } from '@/store/slices/authSlice';
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
@@ -14,7 +14,9 @@ import {
   Clock,
   ArrowUpRight,
   ArrowDownLeft,
-  RefreshCw
+  RefreshCw,
+  Activity,
+  AlertTriangle
 } from 'lucide-react';
 import { formatAddress, formatTokenAmount } from '@/utils/format';
 import toast from 'react-hot-toast';
@@ -23,7 +25,7 @@ export default function DashboardPage() {
   const router = useRouter();
   const dispatch = useAppDispatch();
   const { user, isAuthenticated } = useAppSelector((state) => state.auth);
-  const { status, balance, isLoading } = useAppSelector((state) => state.account);
+  const { status, balance, isLoading, network } = useAppSelector((state) => state.account);
   const { messages } = useAppSelector((state) => state.chat);
 
   useEffect(() => {
@@ -37,6 +39,21 @@ export default function DashboardPage() {
     dispatch(getAccountStatus());
     dispatch(getBalance());
   }, [dispatch, isAuthenticated, router]);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    const refreshNetworkStatus = () => {
+      dispatch(getStellarNetworkStatus());
+    };
+
+    refreshNetworkStatus();
+    const interval = setInterval(refreshNetworkStatus, 15000);
+
+    return () => clearInterval(interval);
+  }, [dispatch, isAuthenticated]);
 
   const copyToClipboard = (text: string, label: string) => {
     navigator.clipboard.writeText(text);
@@ -88,6 +105,38 @@ export default function DashboardPage() {
       color: 'bg-purple-500',
     },
   ];
+
+  const networkStatusLabel =
+    network.status === 'healthy'
+      ? 'Healthy'
+      : network.status === 'degraded'
+        ? 'Degraded'
+        : network.status === 'down'
+          ? 'Down'
+          : 'Checking';
+
+  const networkStatusColor =
+    network.status === 'healthy'
+      ? 'text-green-400'
+      : network.status === 'degraded'
+        ? 'text-yellow-400'
+        : network.status === 'down'
+          ? 'text-red-400'
+          : 'text-gray-300';
+
+  const syncStatusLabel =
+    network.accountSyncState === 'synced'
+      ? 'Synced'
+      : network.accountSyncState === 'syncing'
+        ? 'Syncing'
+        : 'Desynced';
+
+  const syncStatusColor =
+    network.accountSyncState === 'synced'
+      ? 'text-green-400'
+      : network.accountSyncState === 'syncing'
+        ? 'text-yellow-400'
+        : 'text-red-400';
 
   if (!isAuthenticated) {
     return (
@@ -220,6 +269,103 @@ export default function DashboardPage() {
               Refresh
             </Button>
           </Card>
+        </div>
+
+        {/* Stellar Network */}
+        <div className="mb-8">
+          <h2 className="text-2xl font-bold text-white mb-6">
+            Stellar Network
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <Card>
+              <div className="flex items-start justify-between">
+                <div>
+                  <p className="text-sm font-medium text-gray-300">
+                    Network Status
+                  </p>
+                  <div className="flex items-center space-x-2 mt-1">
+                    <Activity className={`h-4 w-4 ${networkStatusColor}`} />
+                    <span className={`text-lg font-semibold ${networkStatusColor}`}>
+                      {networkStatusLabel}
+                    </span>
+                  </div>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => dispatch(getStellarNetworkStatus())}
+                >
+                  Refresh
+                </Button>
+              </div>
+              <div className="mt-4 space-y-2 text-sm text-gray-300">
+                <div className="flex items-center justify-between">
+                  <span>Latest Ledger</span>
+                  <span className="text-white font-medium">
+                    {network.latestLedger ?? 'Loading...'}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Ledger Age</span>
+                  <span className="text-white font-medium">
+                    {network.ledgerAgeSeconds !== null
+                      ? `${network.ledgerAgeSeconds}s`
+                      : 'Loading...'}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Last Updated</span>
+                  <span className="text-white font-medium">
+                    {network.lastUpdated
+                      ? new Date(network.lastUpdated).toLocaleTimeString()
+                      : 'Loading...'}
+                  </span>
+                </div>
+              </div>
+              {network.congestion && (
+                <div className="mt-4 flex items-start space-x-2 rounded-lg bg-yellow-500/10 p-3 text-yellow-300">
+                  <AlertTriangle className="h-4 w-4 mt-0.5" />
+                  <span className="text-sm">
+                    Congestion detected. Transactions may take longer to confirm.
+                  </span>
+                </div>
+              )}
+            </Card>
+
+            <Card>
+              <div className="flex items-start justify-between">
+                <div>
+                  <p className="text-sm font-medium text-gray-300">
+                    Account Sync State
+                  </p>
+                  <div className="flex items-center space-x-2 mt-1">
+                    <span className={`text-lg font-semibold ${syncStatusColor}`}>
+                      {syncStatusLabel}
+                    </span>
+                  </div>
+                  <p className="text-xs text-gray-400 mt-2">
+                    Based on the latest ledger signal from Horizon.
+                  </p>
+                </div>
+              </div>
+              {network.accountSyncState === 'desynced' && (
+                <div className="mt-4 flex items-start space-x-2 rounded-lg bg-red-500/10 p-3 text-red-300">
+                  <AlertTriangle className="h-4 w-4 mt-0.5" />
+                  <span className="text-sm">
+                    Account appears out of sync. Try refreshing or check network conditions.
+                  </span>
+                </div>
+              )}
+              {network.accountSyncState === 'syncing' && (
+                <div className="mt-4 flex items-start space-x-2 rounded-lg bg-yellow-500/10 p-3 text-yellow-300">
+                  <AlertTriangle className="h-4 w-4 mt-0.5" />
+                  <span className="text-sm">
+                    Syncing with the network. Recent updates may be delayed.
+                  </span>
+                </div>
+              )}
+            </Card>
+          </div>
         </div>
 
         {/* Quick Actions */}

--- a/src/store/slices/accountSlice.ts
+++ b/src/store/slices/accountSlice.ts
@@ -2,11 +2,27 @@ import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import { AccountStatus, WalletBalance } from '@/types';
 import apiService from '@/services/api';
 
+type NetworkHealthStatus = 'healthy' | 'degraded' | 'down' | 'unknown';
+type AccountSyncState = 'synced' | 'syncing' | 'desynced';
+
+interface StellarNetworkState {
+  status: NetworkHealthStatus;
+  latestLedger: number | null;
+  ledgerCloseTimeMs: number | null;
+  ledgerAgeSeconds: number | null;
+  congestion: boolean;
+  accountSyncState: AccountSyncState;
+  lastUpdated: string | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
 interface AccountState {
   status: AccountStatus | null;
   balance: WalletBalance | null;
   isLoading: boolean;
   error: string | null;
+  network: StellarNetworkState;
 }
 
 const initialState: AccountState = {
@@ -14,6 +30,17 @@ const initialState: AccountState = {
   balance: null,
   isLoading: false,
   error: null,
+  network: {
+    status: 'unknown',
+    latestLedger: null,
+    ledgerCloseTimeMs: null,
+    ledgerAgeSeconds: null,
+    congestion: false,
+    accountSyncState: 'syncing',
+    lastUpdated: null,
+    isLoading: false,
+    error: null,
+  },
 };
 
 // Async thunks
@@ -45,6 +72,49 @@ export const getBalance = createAsyncThunk(
       }
     } catch (error: any) {
       return rejectWithValue(error.response?.data?.message || 'Failed to get balance');
+    }
+  }
+);
+
+export const getStellarNetworkStatus = createAsyncThunk(
+  'account/getStellarNetworkStatus',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await fetch('https://horizon.stellar.org/ledgers?order=desc&limit=1');
+      if (!response.ok) {
+        return rejectWithValue('Failed to fetch Stellar network status');
+      }
+      const data = await response.json();
+      const latestLedgerRecord = data?._embedded?.records?.[0];
+      if (!latestLedgerRecord) {
+        return rejectWithValue('No ledger data available');
+      }
+
+      const latestLedger = Number(latestLedgerRecord.sequence);
+      const closedAt = latestLedgerRecord.closed_at
+        ? new Date(latestLedgerRecord.closed_at).getTime()
+        : null;
+      const ledgerAgeSeconds = closedAt
+        ? Math.max(0, Math.floor((Date.now() - closedAt) / 1000))
+        : null;
+      const maxTxSetSize = latestLedgerRecord.max_tx_set_size
+        ? Number(latestLedgerRecord.max_tx_set_size)
+        : 0;
+      const successfulTxCount = latestLedgerRecord.successful_transaction_count
+        ? Number(latestLedgerRecord.successful_transaction_count)
+        : 0;
+      const congestion =
+        maxTxSetSize > 0 ? successfulTxCount / maxTxSetSize >= 0.85 : false;
+
+      return {
+        latestLedger,
+        ledgerCloseTimeMs: closedAt,
+        ledgerAgeSeconds,
+        congestion,
+        lastUpdated: new Date().toISOString(),
+      };
+    } catch (error: any) {
+      return rejectWithValue(error.message || 'Failed to fetch Stellar network status');
     }
   }
 );
@@ -153,6 +223,52 @@ const accountSlice = createSlice({
       .addCase(getBalance.rejected, (state, action) => {
         state.isLoading = false;
         state.error = action.payload as string;
+      })
+      // Get Stellar Network Status
+      .addCase(getStellarNetworkStatus.pending, (state) => {
+        state.network.isLoading = true;
+        state.network.error = null;
+        state.network.accountSyncState = 'syncing';
+      })
+      .addCase(getStellarNetworkStatus.fulfilled, (state, action) => {
+        const { latestLedger, ledgerCloseTimeMs, ledgerAgeSeconds, congestion, lastUpdated } =
+          action.payload;
+        let status: NetworkHealthStatus = 'healthy';
+        if (ledgerAgeSeconds !== null && ledgerAgeSeconds > 30) {
+          status = 'down';
+        } else if (ledgerAgeSeconds !== null && ledgerAgeSeconds > 15) {
+          status = 'degraded';
+        } else if (congestion) {
+          status = 'degraded';
+        }
+
+        const accountSyncState: AccountSyncState =
+          ledgerAgeSeconds === null
+            ? 'desynced'
+            : ledgerAgeSeconds > 30
+              ? 'desynced'
+              : ledgerAgeSeconds > 15
+                ? 'syncing'
+                : 'synced';
+
+        state.network = {
+          ...state.network,
+          status,
+          latestLedger,
+          ledgerCloseTimeMs,
+          ledgerAgeSeconds,
+          congestion,
+          lastUpdated,
+          accountSyncState,
+          isLoading: false,
+          error: null,
+        };
+      })
+      .addCase(getStellarNetworkStatus.rejected, (state, action) => {
+        state.network.isLoading = false;
+        state.network.status = 'down';
+        state.network.error = action.payload as string;
+        state.network.accountSyncState = 'desynced';
       })
       // Deploy Account
       .addCase(deployAccount.pending, (state) => {


### PR DESCRIPTION
closes #6 

I have added a Stellar network health polling to the dashboard, with ledger height, ledger age, and sync state plus congestion/desync warnings. Updated the account slice to store network health metadata and provide a real-time fetcher using Horizon.